### PR TITLE
Fix: Adjust EventBus ThreadPoolExecutor configuration

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/event/EventBus.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/event/EventBus.java
@@ -65,7 +65,7 @@ public class EventBus implements IEventBus
         publishers = new HashMap<>();
         
         // create thread pool that will be used by all asynchronous event handlers
-        threadPool = new ThreadPoolExecutor(0, 100,
+        threadPool = new ThreadPoolExecutor(10, 100,
                                             10L, TimeUnit.SECONDS,
                                             new SynchronousQueue<Runnable>(),
                                             new NamedThreadFactory("EventBus"));


### PR DESCRIPTION
The ThreadPoolExecutor in EventBus was configured with a corePoolSize of 0, a maximumPoolSize of 100, and a SynchronousQueue. This configuration can lead to RejectedExecutionExceptions even when the pool has reached its maximum size and all threads are idle. This occurs because new tasks cannot be queued (due to SynchronousQueue requiring an immediate handoff) and new threads cannot be created (as maximumPoolSize is reached).

Changed corePoolSize from 0 to 10. This ensures that up to 10 threads are kept alive, improving the executor's ability to accept new tasks, especially after brief idle periods, by providing threads that are actively polling the queue. Non-core threads (up to maximumPoolSize of 100) will still be created on demand and can time out after 10 seconds of inactivity.

This change aims to mitigate the observed RejectedExecutionExceptions related to the event dispatch mechanism.